### PR TITLE
level 4-1 refactoring code review 반영

### DIFF
--- a/src/main/java/com/example/spring_jscode/controller/BoardController.java
+++ b/src/main/java/com/example/spring_jscode/controller/BoardController.java
@@ -37,7 +37,7 @@ public class BoardController {
     public ResponseEntity updateBoard(@PathVariable("id") Long id,
                                       @RequestBody @Valid BoardRequestDto boardRequestDto) {
         return ResponseEntity.ok()
-                .body(boardService.update(id, boardRequestDto.getTitle(), boardRequestDto.getContent()));
+                .body(boardService.update(id, boardRequestDto));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/example/spring_jscode/controller/BoardController.java
+++ b/src/main/java/com/example/spring_jscode/controller/BoardController.java
@@ -49,6 +49,17 @@ public class BoardController {
     @GetMapping("/search")
     public ResponseEntity searchBoards(@RequestParam(value = "keyword", required = false) String keyword,
                                        @RequestParam(value = "page", required = false) Integer pageSize) {
+        if(keyword.isEmpty()) {
+            if(pageSize == null) {
+                return ResponseEntity.ok()
+                        .body(boardService.findAll(0));
+            }
+            return ResponseEntity.ok()
+                    .body(boardService.findAll(pageSize));
+        }
+        else if(pageSize == null) {
+            pageSize = 0;
+        }
         return ResponseEntity.ok()
                 .body(boardService.findBoardsBySearchingKeyword(keyword, pageSize));
     }

--- a/src/main/java/com/example/spring_jscode/service/BoardService.java
+++ b/src/main/java/com/example/spring_jscode/service/BoardService.java
@@ -50,9 +50,9 @@ public class BoardService {
                 .build();
     }
 
-    public BoardResponseDto update(Long id, String title, String content) {
+    public BoardResponseDto update(Long id, BoardRequestDto boardRequestDto) {
         Board board = boardRepository.findById(id).orElseThrow(() -> new NoSuchElementException("게시판을 찾을 수 없습니다."));
-        board.update(title, content);
+        board.update(boardRequestDto.getTitle(), boardRequestDto.getContent());
         boardRepository.save(board);
         return new BoardResponseDto.Builder()
                 .id(board.getId())

--- a/src/main/java/com/example/spring_jscode/service/BoardService.java
+++ b/src/main/java/com/example/spring_jscode/service/BoardService.java
@@ -23,7 +23,12 @@ public class BoardService {
     public BoardResponseDto create(BoardRequestDto boardRequestDto) {
         Board board = boardRequestDto.toEntity(boardRequestDto);
         Board savedboard = boardRepository.save(board);
-        return BoardResponseDto.fromEntity(savedboard);
+        return new BoardResponseDto.Builder()
+                .id(savedboard.getId())
+                .title(savedboard.getTitle())
+                .content(savedboard.getContent())
+                .createAt(savedboard.getCreateAt())
+                .build();
     }
 
     @Transactional(readOnly = true)
@@ -37,14 +42,24 @@ public class BoardService {
     @Transactional(readOnly = true)
     public BoardResponseDto findById(Long id) {
         Board board = boardRepository.findById(id).orElseThrow(() -> new NoSuchElementException("게시판을 찾을 수 없습니다."));
-        return BoardResponseDto.fromEntity(board);
+        return new BoardResponseDto.Builder()
+                .id(board.getId())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .createAt(board.getCreateAt())
+                .build();
     }
 
     public BoardResponseDto update(Long id, String title, String content) {
         Board board = boardRepository.findById(id).orElseThrow(() -> new NoSuchElementException("게시판을 찾을 수 없습니다."));
         board.update(title, content);
         boardRepository.save(board);
-        return BoardResponseDto.fromEntity(board);
+        return new BoardResponseDto.Builder()
+                .id(board.getId())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .createAt(board.getCreateAt())
+                .build();
     }
 
     public void delete(Long id) {

--- a/src/main/java/com/example/spring_jscode/service/BoardService.java
+++ b/src/main/java/com/example/spring_jscode/service/BoardService.java
@@ -63,6 +63,7 @@ public class BoardService {
     }
 
     public void delete(Long id) {
+        boardRepository.findById(id).orElseThrow(() -> new NoSuchElementException("게시판을 찾을 수 없습니다."));
         boardRepository.deleteById(id);
     }
 

--- a/src/main/java/com/example/spring_jscode/service/BoardService.java
+++ b/src/main/java/com/example/spring_jscode/service/BoardService.java
@@ -29,10 +29,7 @@ public class BoardService {
     @Transactional(readOnly = true)
     public BoardPageResponseDto findAll(Integer pageSize) {
         Page<Board> boardPage = boardRepository.findAllByOrderByCreateAtDesc(PageRequest.of(pageSize, 100));
-        Page<BoardResponseDto> boardDtoPages = boardPage.map(board -> {
-            BoardResponseDto boardResponseDto = BoardResponseDto.fromEntity(board);
-            return boardResponseDto;
-        });
+        Page<BoardResponseDto> boardDtoPages = boardPage.map(BoardResponseDto::fromEntity);
         List<BoardResponseDto> boardDtoPagesContent = boardDtoPages.getContent();
         return BoardPageResponseDto.toDtoFromBoardResponseDto(boardDtoPagesContent, boardPage.getTotalPages(), boardPage.getNumber());
     }
@@ -57,10 +54,7 @@ public class BoardService {
     @Transactional(readOnly = true)
     public BoardPageResponseDto findBoardsBySearchingKeyword(String keyword, Integer pageSize) {
         Page<Board> boardPage = boardRepository.findBoardByTitleContainingOrderByCreateAtDesc(keyword, PageRequest.of(pageSize, 100));
-        Page<BoardResponseDto> boardDtoPages = boardPage.map(board -> {
-            BoardResponseDto boardResponseDto = BoardResponseDto.fromEntity(board);
-            return boardResponseDto;
-        });
+        Page<BoardResponseDto> boardDtoPages = boardPage.map(BoardResponseDto::fromEntity);
         List<BoardResponseDto> boardDtoPagesContent = boardDtoPages.getContent();
         return BoardPageResponseDto.toDtoFromBoardResponseDto(boardDtoPagesContent, boardPage.getTotalPages(), boardPage.getNumber());
     }


### PR DESCRIPTION
### 이중 콜론 연산자 사용(::)
해당 연산자를 사용하여 코드 길이 줄임

### Dto및 Entity 생성 패턴을 Builder로 구현
나중에 요구사항이 많아질 경우를 대비해서 builder로 구현

### update 매개변수 Dto로 통일
기존 Service의 create메서드의 매개변수처럼 RequestDto 통째로 service 로직에 넘김

### delete 기능 유효성 검사 로직 추가
findById를 통해서 id값에 맞는 게시글이 있는지 조사하는 로직 추가

### 검색 API에 대한 유효성 검사 처리 로직 추가
keyword가 null값이 전해질 경우 findAll을 통해 전체 페이지를 반환하도록 하고,
pageSize가 null값이 전해질 경우 인자로 0을 보내 첫페이지를 반환

# 🤔 **궁금한 점**
@mog-hi @jaeseongDev 
### 매개변수 설정
```java
board.update(boardRequestDto.getTitle(), boardRequestDto.getContent());
```
이친구의 인자를 이렇게 전달해버리면, 나중에 boardRequestDto에 필드값이 하나 더 생겼다면 이 코드를 다 수정해야 하고,

그럼 boardRequestDto 자체를 넘겨주게 되면 또
board의 update 메서드에서 BoardRequestDto에 의존관계가 생기게 되고...

어떻게 구현하는게 유지보수에 제일 좋을까요..?
Dto를 Layer간 전달할 때 어떻게 전달하는지 알려주세요!

### 람다 함수와 빌더 패턴
```
Page<BoardResponseDto> boardDtoPages = boardPage.map(BoardResponseDto::fromEntity);
```
여기서 fromEntity는 static factory method인데
만일 builder 패턴으로 바꿀 경우
해당 람다 함수를 사용할 수 없게 됩니다..

빌더를 사용하고 싶을 때는 `::` 대신 `() -> { ~~ }` 형태를 사용해야 할까요..?
만일 `() -> { ~~ }` 형태를 사용한다면, 코드가 길어져서
따로 메서드로 만들어 로직을 빼는것이 좋을까요?

우선 ResponseDto에서는 Builder와 static factory method 둘 다 구현하고 있습니다..

### 검색 로직
```java
@GetMapping("/search")
    public ResponseEntity searchBoards(@RequestParam(value = "keyword", required = false) String keyword,
                                       @RequestParam(value = "page", required = false) Integer pageSize) {
        if(keyword.isEmpty()) {
            if(pageSize == null) {
                return ResponseEntity.ok()
                        .body(boardService.findAll(0));
            }
            return ResponseEntity.ok()
                    .body(boardService.findAll(pageSize));
        }
        else if(pageSize == null) {
            pageSize = 0;
        }
        return ResponseEntity.ok()
                .body(boardService.findBoardsBySearchingKeyword(keyword, pageSize));
    }
```
이렇게 if문을 남발하게 되는데..
더 좋은 패턴이 있을까요..?