### PR TITLE
level 7 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'o.jsonwebtoken:jjwt:0.9.1'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'o.jsonwebtoken:jjwt:0.9.1'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/spring_jscode/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/spring_jscode/config/WebSecurityConfig.java
@@ -1,0 +1,30 @@
+package com.example.spring_jscode.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
+        return http
+                .httpBasic().disable()
+                .csrf().disable()
+                .cors().and()
+                .authorizeRequests()
+                .antMatchers("/user/login", "/user/signup").permitAll()
+                .antMatchers(HttpMethod.GET, "/boards/**").authenticated()
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                // .addFilterBefore(new JwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/com/example/spring_jscode/controller/UserController.java
+++ b/src/main/java/com/example/spring_jscode/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.example.spring_jscode.controller;
+
+import com.example.spring_jscode.dto.UserRequestDto;
+import com.example.spring_jscode.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity signup(@RequestBody @Valid UserRequestDto userRequestDto) {
+        return ResponseEntity.ok()
+                .body("성공적으로 생성되었습니다.");
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity login(@RequestBody @Valid UserRequestDto userRequestDto) {
+        return ResponseEntity.ok()
+                .body(userService.login(userRequestDto));
+    }
+}

--- a/src/main/java/com/example/spring_jscode/controller/advice/ErrorCode.java
+++ b/src/main/java/com/example/spring_jscode/controller/advice/ErrorCode.java
@@ -9,6 +9,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 400
     INVALID_TITLE_CONTENT(HttpStatus.BAD_REQUEST, "제목 혹은 내용이 유효하지 않습니다."),
+    EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "동일한 이메일이 이미 존재합니다."),
+    // 401
+    UNAUTHENTICATED_EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 헤더에 존재하지 않습니다."),
+    UNAUTHENTICATED_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+    UNAUTHENTICATED_EMPTY_USERID(HttpStatus.UNAUTHORIZED, "헤더 안의 user id값이 존재하지 않습니다."),
     // 404
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시판을 찾을 수 없습니다."),
     // 500

--- a/src/main/java/com/example/spring_jscode/domain/entity/User.java
+++ b/src/main/java/com/example/spring_jscode/domain/entity/User.java
@@ -1,0 +1,21 @@
+package com.example.spring_jscode.domain.entity;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long id;
+    private String email;
+
+    private String password;
+
+    @Column(name = "signup_at")
+    private LocalDateTime signupAt;
+    @PrePersist
+    protected void onCreate() {
+       signupAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/spring_jscode/domain/entity/User.java
+++ b/src/main/java/com/example/spring_jscode/domain/entity/User.java
@@ -1,13 +1,20 @@
 package com.example.spring_jscode.domain.entity;
 
+import com.example.spring_jscode.exception.CustomException;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
+@NoArgsConstructor
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private long id;
+
     private String email;
 
     private String password;
@@ -17,5 +24,14 @@ public class User {
     @PrePersist
     protected void onCreate() {
        signupAt = LocalDateTime.now();
+    }
+
+    private User(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    public static User create(String email, String password) {
+        return new User(email, password);
     }
 }

--- a/src/main/java/com/example/spring_jscode/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/spring_jscode/domain/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.spring_jscode.domain.repository;
+
+import com.example.spring_jscode.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/example/spring_jscode/dto/UserRequestDto.java
+++ b/src/main/java/com/example/spring_jscode/dto/UserRequestDto.java
@@ -1,0 +1,24 @@
+package com.example.spring_jscode.dto;
+
+import com.example.spring_jscode.domain.entity.User;
+import lombok.Getter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+
+@Getter
+public class UserRequestDto {
+    @Email(message = "이메일 형식으로 입력하세요")
+    @NotEmpty(message = "이메일은 공백이 올 수 없습니다.")
+    private String email;
+
+    @NotEmpty(message = "패스워드는 공백이 올 수 없습니다.")
+    @Size(min = 8, max = 15, message = "8자 이상 15자 이하여야 합니다.")
+    private String password;
+
+    public User toEntity(UserRequestDto userRequestDto) {
+        return User.create(userRequestDto.getEmail(),
+                userRequestDto.getPassword());
+    }
+}

--- a/src/main/java/com/example/spring_jscode/dto/UserResponseDto.java
+++ b/src/main/java/com/example/spring_jscode/dto/UserResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.spring_jscode.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserResponseDto {
+
+}

--- a/src/main/java/com/example/spring_jscode/service/UserService.java
+++ b/src/main/java/com/example/spring_jscode/service/UserService.java
@@ -1,0 +1,32 @@
+package com.example.spring_jscode.service;
+
+import com.example.spring_jscode.controller.advice.ErrorCode;
+import com.example.spring_jscode.domain.entity.User;
+import com.example.spring_jscode.domain.repository.UserRepository;
+import com.example.spring_jscode.dto.UserRequestDto;
+import com.example.spring_jscode.exception.CustomException;
+import com.example.spring_jscode.utils.TokenUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    public void create(UserRequestDto userRequestDto) {
+        userRepository.findByEmail(userRequestDto.getEmail()).orElseThrow(
+                () -> new CustomException(ErrorCode.EMAIL_ALREADY_EXIST));
+        userRepository.save(userRequestDto.toEntity(userRequestDto));
+    }
+
+    public String login(UserRequestDto userRequestDto) {
+        return TokenUtils.createToken(userRequestDto.getEmail(),
+                secretKey,
+                1000 * 60 * 60l);
+    }
+}

--- a/src/main/java/com/example/spring_jscode/utils/TokenUtils.java
+++ b/src/main/java/com/example/spring_jscode/utils/TokenUtils.java
@@ -1,0 +1,22 @@
+package com.example.spring_jscode.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import java.util.Date;
+
+public class TokenUtils {
+
+    public static String createToken(String username, String secretKey, Long expiredMilliSecond) {
+        Claims claims = Jwts.claims();
+        claims.put("username", username);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expiredMilliSecond))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,3 +23,6 @@ spring:
     hiddenmethod:
       filter:
         enabled: true
+
+jwt:
+  secret: mynameisbaksakcci.ee.ff


### PR DESCRIPTION
# 구현 내용
### 요구사항 분석
- 회원 가입
회원가입은 Token을 발급할 필요가 없기 때문에 유효성 검사 및 중복 여부만 조사한 후 DB에 저장
![](https://i.imgur.com/kiUBHyA.jpg)
- 로그인
id, pw를 체크한 후 서버의 비밀키를 사용하여 JWT를 생성하고 클라이언트에게 발급
![](https://i.imgur.com/7uzDboA.jpg)
- 이외 기능
내정보 조회, 게시판 수정 등 User의 인증을 필요로 하는 기능들에 Header 체크하는 기능을 추가. 이는 Filter 혹은 Intercepter를 사용
![](https://i.imgur.com/f2mOwsu.jpg)
---
### User Entity 생성 및 CRUD 구현
- UserRequestDto 검증 추가, 커스텀 에러 핸들링
- 회원가입 및 로그인에 필요한 `find`, `create` 구현
---
### 토큰 생성
- `WebSecurityConfig` 설정
- `UserService` 내에 토큰 생성 로직 구현
- 임시 로직이기 때문에 토큰 만료기간 및 비밀키 임의 실정
---
# 🤔 궁금한 점
### Spring Security를 제대로 학습하려 하는데 너무 어렵습니다..
어떤게 궁금한지도 모르는 상태입니다..
[스프링 시큐리티 주요 아키텍처 이해](https://catsbi.oopy.io/f9b0d83c-4775-47da-9c81-2261851fe0d0)
해당 포스팅을 참고해서 공부하면 좋을까요..? 학습하기 좋은 글을 추천해주세요..!

### 유효성 검사 예외처리
현재 `@Valid`로 유효성 검사를 진행하는데,
`@RestControllerAdvice`를 이용해서 유효성 검사에 실패하면 무조껀 `MethodArgumentNotValidException` 예외가 발생하도록 구현 되어있는 것 같습니다
`MethodArgumentNotValidExceptionHandler`로 처리하고 있는데, 어떤 유효성 검사든 다 저 Handler로 넘어와서 예외 처리를 하다보니 예외 메세지를 한개밖에 처리를 못합니다..

예를 들어, `User`클래스의 `email`을 `@NotEmpty`를 통해 검사하게 되는데, 여기서 에러가 나도 `MethodArgumentNotValidExceptionHandler`로 처리됩니다.
`Board`의 `title` 유효성 검사도 마찬가지로 에러가 나도,
`MethodArgumentNotValidExceptionHandler`로 처리됩니다.

어떻게 하면 각각 다르게 예외 처리를 할 수 있을까요..?
@Valid를 사용하지 말아야 할까요?

```java
// Spring Request Validation
@ExceptionHandler(MethodArgumentNotValidException.class)
public ResponseEntity<ErrorResponse> MethodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
    return ErrorResponse.toResponseEntity(ErrorCode.INVALID_TITLE_CONTENT);
}
```